### PR TITLE
feature/attraction attraction api update, cors config

### DIFF
--- a/be/src/main/java/ssafy/antalbum/config/WebSecurityConfig.java
+++ b/be/src/main/java/ssafy/antalbum/config/WebSecurityConfig.java
@@ -23,6 +23,8 @@ import ssafy.antalbum.config.oauth.OAuth2UserCustomService;
 import ssafy.antalbum.repository.RefreshTokenRepository;
 import ssafy.antalbum.service.UserService;
 
+import java.util.Arrays;
+
 @RequiredArgsConstructor
 @Configuration
 public class WebSecurityConfig {
@@ -87,6 +89,17 @@ public class WebSecurityConfig {
 
 
         return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:8080");
+        configuration.setAllowedMethods(Arrays.asList("GET","POST", "OPTIONS", "PUT","DELETE"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/be/src/main/java/ssafy/antalbum/controller/AttractionController.java
+++ b/be/src/main/java/ssafy/antalbum/controller/AttractionController.java
@@ -18,7 +18,7 @@ public class AttractionController {
 
     private final AttractionService attractionService;
 
-    @GetMapping("api/attraction")
+    @GetMapping("attraction")
     public ResponseEntity<List<Attraction>> findAllAttractions() {
 
         List<Attraction> attractions = attractionService.findAll();
@@ -27,7 +27,7 @@ public class AttractionController {
     }
 
     // default : [0, 0, ""]
-    @PostMapping("api/attraction/condition")
+    @PostMapping("attraction/condition")
     public ResponseEntity<List<Attraction>> findByCondition(@RequestBody SearchCondition condition) {
 
         List<Attraction> attractions = attractionService.findByCondition(condition);

--- a/be/src/main/java/ssafy/antalbum/repository/AttractionRepositsory.java
+++ b/be/src/main/java/ssafy/antalbum/repository/AttractionRepositsory.java
@@ -3,6 +3,10 @@ package ssafy.antalbum.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ssafy.antalbum.entity.Attraction;
 
+import java.util.List;
+
 public interface AttractionRepositsory extends JpaRepository<Attraction, Long>, AttractionRepositoryCustom {
+
+    List<Attraction> findTop100ByOrderByReadCountDesc();
 
 }

--- a/be/src/main/java/ssafy/antalbum/service/AttractionService.java
+++ b/be/src/main/java/ssafy/antalbum/service/AttractionService.java
@@ -15,7 +15,8 @@ public class AttractionService {
     private final AttractionRepositsory attractionRepository;
 
     public List<Attraction> findAll() {
-        return attractionRepository.findAll();
+//        return attractionRepository.findAll();
+        return attractionRepository.findTop100ByOrderByReadCountDesc();
     }
 
     public List<Attraction> findByCondition(SearchCondition searchCondition) {

--- a/be/src/main/resources/application.yml
+++ b/be/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true
@@ -22,7 +22,7 @@ spring:
         registration:
           google:
             client-id: 892345291366-rnpj77i32do1275oa8g7hjct6riiltm2.apps.googleusercontent.com
-            client-secret: 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
+            client-secret: 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
             scope:
               - email
               - profile


### PR DESCRIPTION
## What is this PR?
- attraction api 수정
- cors config (8080:* allow all)

## Changes
- attraction list api를 조회수 기준으로 탑 100개만 가져오도록 수정했습니다. 
- spring security cors 관련해 8080포트의 요청을 모두 허용하도록 설정했습니다.

## Test Checklist - to Reviewrs
- [ ] attraction list 페이지가 정상 작동하는지 확인해주세요
- [ ] (cors) 기존의 여행 생성 api가 잘 작동되는지 확인해주세요
