### PR TITLE
사용자 여행 리스트 보기

### DIFF
--- a/be/src/main/java/ssafy/antalbum/controller/TravelAPIController.java
+++ b/be/src/main/java/ssafy/antalbum/controller/TravelAPIController.java
@@ -8,13 +8,18 @@ import java.util.List;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import ssafy.antalbum.dto.CreateTravelInfoRequest;
+import ssafy.antalbum.dto.CreateTravelInfoResponse;
+import ssafy.antalbum.dto.TravelDto;
 import ssafy.antalbum.entity.travel.Travel;
 import ssafy.antalbum.service.TravelService;
+import ssafy.antalbum.service.UserService;
 
 @CrossOrigin(origins = "*", allowedHeaders = "*")
 @RestController
@@ -24,8 +29,8 @@ public class TravelAPIController {
     private final TravelService travelService;
 
     @PostMapping("/apii/v1/travel/info")
-    public CreateTravelInfoResponse createTravelInfo(@RequestBody @Valid Travel travel) {
-        Long id = travelService.create(travel);
+    public CreateTravelInfoResponse createTravelInfo(@RequestBody @Valid CreateTravelInfoRequest request) {
+        Long id = travelService.create(request);
         return new CreateTravelInfoResponse(id);
     }
 
@@ -38,13 +43,9 @@ public class TravelAPIController {
         return new CreateTravelInfoResponse(Long.parseLong(travel));
     }
 
-    @Data
-    static class CreateTravelInfoResponse {
-        private Long id;
-
-        public CreateTravelInfoResponse(Long id) {
-            this.id = id;
-        }
+    @GetMapping("/apii/v1/travel")
+    public List<TravelDto> listTravel(@RequestParam("id") String user) {
+        return null;
     }
 
 }

--- a/be/src/main/java/ssafy/antalbum/controller/TravelAPIController.java
+++ b/be/src/main/java/ssafy/antalbum/controller/TravelAPIController.java
@@ -5,10 +5,10 @@ import jakarta.validation.Valid;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.List;
-import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -17,9 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 import ssafy.antalbum.dto.CreateTravelInfoRequest;
 import ssafy.antalbum.dto.CreateTravelInfoResponse;
 import ssafy.antalbum.dto.TravelDto;
-import ssafy.antalbum.entity.travel.Travel;
 import ssafy.antalbum.service.TravelService;
-import ssafy.antalbum.service.UserService;
 
 @CrossOrigin(origins = "*", allowedHeaders = "*")
 @RestController
@@ -43,9 +41,9 @@ public class TravelAPIController {
         return new CreateTravelInfoResponse(Long.parseLong(travel));
     }
 
-    @GetMapping("/apii/v1/travel")
-    public List<TravelDto> listTravel(@RequestParam("id") String user) {
-        return null;
+    @GetMapping("/apii/v1/travel/{userid}")
+    public List<TravelDto> listTravel(@PathVariable("userid") Long userId) {
+        return travelService.findAllTravelInfo(userId);
     }
 
 }

--- a/be/src/main/java/ssafy/antalbum/controller/TravelAPIController.java
+++ b/be/src/main/java/ssafy/antalbum/controller/TravelAPIController.java
@@ -30,11 +30,12 @@ public class TravelAPIController {
     }
 
     @PostMapping("/apii/v1/travel/photo")
-    public void addTravelPhoto(@RequestParam("id") String travel,
+    public CreateTravelInfoResponse addTravelPhoto(@RequestParam("id") String travel,
             @RequestParam("files") List<MultipartFile> files,
             @RequestParam("names") List<String> names)
             throws IOException, ImageProcessingException, ParseException {
         travelService.updatePhoto(Long.parseLong(travel), files, names);
+        return new CreateTravelInfoResponse(Long.parseLong(travel));
     }
 
     @Data

--- a/be/src/main/java/ssafy/antalbum/dto/CreateTravelInfoRequest.java
+++ b/be/src/main/java/ssafy/antalbum/dto/CreateTravelInfoRequest.java
@@ -1,0 +1,14 @@
+package ssafy.antalbum.dto;
+
+import java.util.List;
+import lombok.Getter;
+import ssafy.antalbum.entity.tag.Tag;
+import ssafy.antalbum.entity.tag.TagStatus;
+import ssafy.antalbum.entity.travel.Travel;
+
+@Getter
+public class CreateTravelInfoRequest {
+    private Travel travel;
+    private List<MemberDto> members;
+}
+

--- a/be/src/main/java/ssafy/antalbum/dto/CreateTravelInfoResponse.java
+++ b/be/src/main/java/ssafy/antalbum/dto/CreateTravelInfoResponse.java
@@ -1,0 +1,12 @@
+package ssafy.antalbum.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateTravelInfoResponse {
+    private Long id;
+
+    public CreateTravelInfoResponse(Long id) {
+        this.id = id;
+    }
+}

--- a/be/src/main/java/ssafy/antalbum/dto/MemberDto.java
+++ b/be/src/main/java/ssafy/antalbum/dto/MemberDto.java
@@ -1,0 +1,10 @@
+package ssafy.antalbum.dto;
+
+import lombok.Getter;
+import ssafy.antalbum.entity.tag.TagStatus;
+
+@Getter
+public class MemberDto {
+    private Long userId;
+    private TagStatus tagStatus;
+}

--- a/be/src/main/java/ssafy/antalbum/dto/TravelDto.java
+++ b/be/src/main/java/ssafy/antalbum/dto/TravelDto.java
@@ -1,0 +1,8 @@
+package ssafy.antalbum.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TravelDto {
+
+}

--- a/be/src/main/java/ssafy/antalbum/dto/TravelDto.java
+++ b/be/src/main/java/ssafy/antalbum/dto/TravelDto.java
@@ -1,8 +1,34 @@
 package ssafy.antalbum.dto;
 
+import java.text.Format;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Locale;
 import lombok.Getter;
+import ssafy.antalbum.entity.travel.Travel;
 
 @Getter
 public class TravelDto {
+
+    private String title;
+    private String description;
+    private String duration;
+    private String thumbnail;
+
+    public TravelDto(Travel travel, List<String> duration) {
+        this.title = travel.getTitle();
+        this.description = travel.getDescription();
+        this.duration = convertDuration(duration);
+        this.thumbnail = travel.getThumbnail();
+    }
+
+    private String convertDuration(List<String> duration) {
+        if (duration.size() == 0) return "No dates";
+
+        Format formatter = new SimpleDateFormat("MMM.yyyy", Locale.ENGLISH);
+        String first = formatter.format(duration.get(0));
+        String last = formatter.format(duration.get(duration.size() - 1));
+        return String.format("%s ~ %s", first, last);
+      }
 
 }

--- a/be/src/main/java/ssafy/antalbum/entity/photo/Photo.java
+++ b/be/src/main/java/ssafy/antalbum/entity/photo/Photo.java
@@ -13,6 +13,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Locale;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,7 +56,7 @@ public class Photo {
     public String getDate(Photo photo) throws ParseException {
         if (photo.getPhotoMeta().getDateTimeOriginal().equals("")) return null;
 
-        DateFormat format = new SimpleDateFormat("E MMM dd HH:mm:ss z yyyy");
+        SimpleDateFormat format = new SimpleDateFormat("E MMM dd HH:mm:ss z yyyy", Locale.ENGLISH);
         Date date = format.parse(photo.getPhotoMeta().getDateTimeOriginal());
         SimpleDateFormat formatter = new SimpleDateFormat("yyyy/MM/dd");
         return formatter.format(date);

--- a/be/src/main/java/ssafy/antalbum/entity/photo/PhotoMeta.java
+++ b/be/src/main/java/ssafy/antalbum/entity/photo/PhotoMeta.java
@@ -21,13 +21,15 @@ public class PhotoMeta {
     private String gpsAltitude;
     private String detectedFileTypeName;
     private String detectedMIMEType;
+    private String expectedFileNameExtension;
 
     @Builder
     public PhotoMeta(String dateTimeOriginal, String timeZoneOriginal,
             String gpsLatitudeRef, String gpsLatitude,
             String gpsLongitudeRef, String gpsLongitude,
             String gpsAltitudeRef, String gpsAltitude,
-            String detectedFileTypeName, String detectedMIMEType) {
+            String detectedFileTypeName, String detectedMIMEType,
+            String expectedFileNameExtension) {
 
         this.dateTimeOriginal = dateTimeOriginal;
         this.timeZoneOriginal = timeZoneOriginal;
@@ -39,6 +41,7 @@ public class PhotoMeta {
         this.gpsAltitude = gpsAltitude;
         this.detectedFileTypeName = detectedFileTypeName;
         this.detectedMIMEType = detectedMIMEType;
+        this.expectedFileNameExtension = expectedFileNameExtension;
     }
 
 }

--- a/be/src/main/java/ssafy/antalbum/entity/photo/PhotoPath.java
+++ b/be/src/main/java/ssafy/antalbum/entity/photo/PhotoPath.java
@@ -23,10 +23,10 @@ public class PhotoPath {
         this.originalFileName = originalFileName;
     }
 
-    public static PhotoPath createPhotoPath(String bucketName, String travel_id, String fileName) {
+    public static PhotoPath createPhotoPath(String bucketName, String travel_id, String fileName, String extension) {
         return PhotoPath.builder()
                 .url(String.format("%s/%s", bucketName, travel_id))
-                .encodedFileName(String.valueOf(UUID.randomUUID()))
+                .encodedFileName(String.format("%s.%s", String.valueOf(UUID.randomUUID()), extension))
                 .originalFileName(fileName)
                 .build();
     }

--- a/be/src/main/java/ssafy/antalbum/entity/tag/Tag.java
+++ b/be/src/main/java/ssafy/antalbum/entity/tag/Tag.java
@@ -10,8 +10,10 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import ssafy.antalbum.dto.MemberDto;
 import ssafy.antalbum.entity.travel.Travel;
 import ssafy.antalbum.entity.user.User;
 
@@ -35,4 +37,19 @@ public class Tag {
 
     @Enumerated(EnumType.STRING)
     private TagStatus tagStatus;
+
+    @Builder
+    public Tag(Travel travel, User user, TagStatus tagStatus) {
+        this.travel = travel;
+        this.user = user;
+        this.tagStatus = tagStatus;
+    }
+
+    public static Tag createTag(Travel travel, User user, TagStatus tagStatus) {
+        return Tag.builder()
+                .travel(travel)
+                .user(user)
+                .tagStatus(tagStatus)
+                .build();
+    }
 }

--- a/be/src/main/java/ssafy/antalbum/entity/travel/Travel.java
+++ b/be/src/main/java/ssafy/antalbum/entity/travel/Travel.java
@@ -42,4 +42,8 @@ public class Travel {
     @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL)
     private List<Adventure> adventures;
 
+    public void addTags(List<Tag> tags) {
+        this.tags = tags;
+    }
+
 }

--- a/be/src/main/java/ssafy/antalbum/entity/travel/Travel.java
+++ b/be/src/main/java/ssafy/antalbum/entity/travel/Travel.java
@@ -1,6 +1,5 @@
 package ssafy.antalbum.entity.travel;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,8 +41,13 @@ public class Travel {
     @OneToMany(mappedBy = "travel", cascade = CascadeType.ALL)
     private List<Adventure> adventures;
 
+    private String thumbnail;
+
     public void addTags(List<Tag> tags) {
         this.tags = tags;
     }
 
+    public void updateThumbnail(String url) {
+        this.thumbnail = url;
+    }
 }

--- a/be/src/main/java/ssafy/antalbum/repository/TravelRepository.java
+++ b/be/src/main/java/ssafy/antalbum/repository/TravelRepository.java
@@ -1,9 +1,9 @@
 package ssafy.antalbum.repository;
 
 import jakarta.persistence.EntityManager;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
-import ssafy.antalbum.entity.photo.Photo;
 import ssafy.antalbum.entity.travel.Travel;
 
 @Repository
@@ -23,4 +23,23 @@ public class TravelRepository {
     public void updateWithPhotosAndAdventures(Travel travel) {
         em.persist(travel);
     }
+
+    public List<Travel> findAllTravelsWithUser(Long userId) {
+        return em.createQuery(
+                        "select t from Travel t where t.id in " +
+                                "(select t2.travel.id from Tag t2" +
+                                " where t2.user.id = :userId)", Travel.class)
+                .setParameter("userId", userId)
+                .getResultList();
+    }
+
+    public List<String> findTravelDuration(Long travelId) {
+        return em.createQuery(
+                "select a.date from AdventureDate a" +
+                        " where a.travel.id = :travelId" +
+                        " order by a.date", String.class)
+                .setParameter("travelId", travelId)
+                .getResultList();
+    }
+
 }

--- a/be/src/main/java/ssafy/antalbum/service/AmazonS3Service.java
+++ b/be/src/main/java/ssafy/antalbum/service/AmazonS3Service.java
@@ -9,9 +9,7 @@ import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 import ssafy.antalbum.entity.photo.PhotoPath;
-import ssafy.antalbum.util.PhotoUtil;
 
 @Service
 public class AmazonS3Service {
@@ -19,7 +17,10 @@ public class AmazonS3Service {
     @Autowired
     private AmazonS3 amazonS3;
 
-    public PutObjectResult upload(
+    @Value("${aws.s3.bucket.name}")
+    private String bucketName;
+
+    public String upload(
             PhotoPath photoPath, Map<String, String> metadata, InputStream inputStream) {
 
         ObjectMetadata objectMetadata = new ObjectMetadata();
@@ -30,7 +31,11 @@ public class AmazonS3Service {
             }
         });
 
-        return amazonS3.putObject(
+        PutObjectResult objectResult = amazonS3.putObject(
                 photoPath.getUrl(), photoPath.getEncodedFileName(), inputStream, objectMetadata);
+
+        String path = String.format("%s/%s", photoPath.getUrl().split("/")[1], photoPath.getEncodedFileName());
+        return amazonS3.getUrl(bucketName, path).toString();
     }
+
 }

--- a/be/src/main/java/ssafy/antalbum/util/PhotoUtil.java
+++ b/be/src/main/java/ssafy/antalbum/util/PhotoUtil.java
@@ -37,6 +37,7 @@ public class PhotoUtil {
         FileTypeDirectory type_dir = metadata.getFirstDirectoryOfType(FileTypeDirectory.class);
         String detected_type = type_dir == null ? "" : type_dir.getString(FileTypeDirectory.TAG_DETECTED_FILE_TYPE_NAME);
         String detected_mime = type_dir == null ? "" : type_dir.getString(FileTypeDirectory.TAG_DETECTED_FILE_MIME_TYPE);
+        String extension = type_dir == null ? "" : type_dir.getString(FileTypeDirectory.TAG_EXPECTED_FILE_NAME_EXTENSION);
 
         PhotoMeta photoMeta = PhotoMeta.builder()
                 .dateTimeOriginal(datetime == null ? null : datetime.toString())
@@ -49,6 +50,7 @@ public class PhotoUtil {
                 .gpsAltitude(altitude)
                 .detectedFileTypeName(detected_type)
                 .detectedMIMEType(detected_mime)
+                .expectedFileNameExtension(extension)
                 .build();
 
         return photoMeta;
@@ -56,7 +58,7 @@ public class PhotoUtil {
 
     public static Map<String, String> extractAWSMetaData(MultipartFile file) {
         Map<String, String> metadata = new HashMap<>();
-        metadata.put("Content-Type", file.getContentType());
+        metadata.put("Content-Type", "image/jpeg");
         metadata.put("Content-Length", String.valueOf(file.getSize()));
 
         return metadata;


### PR DESCRIPTION
## What is this PR?
- 여행 리스트 보기를 위한 부분을 구현했습니다.
  ![image](https://github.com/AntAlbum/frontend/assets/33994508/693b8706-3191-4636-9170-64f38b6e9e58)

## Changes
1. 사용자별로 여행을 가져와야 해서 그 부분을 수정했습니다. 다만 코드에서는 user_id가 1인 경우만을 가져오도록 했는데, 이 점은 앞으로 개선해야 합니다.
2. 백엔드 부분에서 여행 등록 시 자동으로 썸네일 사진을 고르고(가장 첫 날의 첫 번째 사진), 그 사진의 링크를 가져와 리스트 뷰에서 띄우게 했습니다.
3. 백엔드 부분에서 여행 등록 시 자동으로 첫번째 사진이 찍힌 날짜, 마지막으로 사진이 찍힌 날짜를 가져와 여행 기간을 표시하도록 했습니다.

close #32