### PR TITLE
여행 상세보기 -> 태그된 친구 프로필 띄우기 기능

### DIFF
--- a/be/src/main/java/ssafy/antalbum/dto/FriendDto.java
+++ b/be/src/main/java/ssafy/antalbum/dto/FriendDto.java
@@ -6,11 +6,13 @@ import lombok.Getter;
 public class FriendDto {
 
     private Long id;
+    private String nickname;
     private String profile;
 
     public FriendDto(Object[] info) {
         this.id = (Long) info[0];
-        this.profile = (String) info[1];
+        this.nickname = (String) info[1];
+        this.profile = (String) info[2];
     }
 
 }

--- a/be/src/main/java/ssafy/antalbum/repository/TravelRepository.java
+++ b/be/src/main/java/ssafy/antalbum/repository/TravelRepository.java
@@ -62,7 +62,7 @@ public class TravelRepository {
 
     public List<Object[]> findTaggedFriends(Long travelId) {
         return em.createQuery(
-                "select u.id, u.profile from User u" +
+                "select u.id, u.nickname, u.profile from User u" +
                         " where u.id in ("+""+
                         " select t.user.id from Tag t" +
                         " where t.travel.id = :travelId" +


### PR DESCRIPTION
## What is this PR?
- 여행 상세보기 기능에서 태그된 친구의 프로필을 띄울 수 있습니다.

## Changes
- 여행 상세보기 기능에서 태그된 친구의 프로필을 띄웁니다.
- 원래는 자신의 프로필을 제외해야 하지만, User 기능을 더 보완해야 이 기능을 완료할 수 있습니다.
- 만들어진 기능은 다음과 같습니다.
  <img width="1412" alt="Screenshot 2023-05-29 at 8 20 39 PM" src="https://github.com/AntAlbum/backend/assets/33994508/663e12d6-a5aa-44e1-aeed-aa188da0050d">

close #38 